### PR TITLE
Support for Transport streamable http

### DIFF
--- a/MCP_HTTP_README.md
+++ b/MCP_HTTP_README.md
@@ -1,0 +1,299 @@
+# VidSnatch MCP HTTP Transport
+
+VidSnatch now supports **streamable HTTP transport** in addition to the original stdio transport, enabling remote MCP server deployment and web-based integrations.
+
+## Overview
+
+The HTTP transport implements the modern MCP standard for remote communication:
+- **Single `/mcp` endpoint** for all MCP communication
+- **Server-Sent Events (SSE)** streaming for long-running operations
+- **CORS support** for web-based clients
+- **Remote deployment** capabilities
+
+## Architecture
+
+```
+┌─────────────────┐    ┌─────────────────┐    ┌─────────────────┐
+│   MCP Client    │    │  HTTP Transport │    │  Shared Tools   │
+│  (Claude, etc.) │◄──►│   mcp_http_     │◄──►│   mcp_tools.py  │
+│                 │    │   server.py     │    │                 │
+└─────────────────┘    └─────────────────┘    └─────────────────┘
+                                │
+                                ▼
+                       ┌─────────────────┐
+                       │  Configuration  │
+                       │  mcp_config.py  │
+                       └─────────────────┘
+```
+
+## Quick Start
+
+### 1. Start HTTP MCP Server
+
+```bash
+# Using Python directly
+python3 mcp_http_server.py
+
+# Using entry point (after installation)
+vidsnatch-mcp-http
+```
+
+The server will start on `http://0.0.0.0:8090` by default.
+
+### 2. Test the Server
+
+```bash
+# Check server info
+curl http://localhost:8090/
+
+# Initialize MCP connection
+curl -X POST http://localhost:8090/mcp \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "method": "initialize",
+    "params": {
+      "protocolVersion": "2024-11-05",
+      "clientInfo": {"name": "test-client", "version": "1.0.0"}
+    }
+  }'
+
+# List available tools
+curl -X POST http://localhost:8090/mcp \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": "2",
+    "method": "tools/list"
+  }'
+```
+
+## Configuration
+
+Configure HTTP transport in `mcp_config.json`:
+
+```json
+{
+  "download_directory": "./downloads",
+  "default_video_quality": "highest",
+  "default_audio_quality": "highest",
+  "max_file_size_mb": 500,
+  "allowed_formats": ["mp4", "webm", "mp3", "m4a"],
+  "create_subdirs": true,
+  "http_transport": {
+    "enabled": true,
+    "host": "0.0.0.0",
+    "port": 8090,
+    "enable_cors": true,
+    "stream_downloads": true
+  }
+}
+```
+
+### Environment Variables
+
+Override configuration with environment variables:
+
+```bash
+export VIDSNATCH_HTTP_HOST="127.0.0.1"
+export VIDSNATCH_HTTP_PORT="8091"
+export VIDSNATCH_HTTP_ENABLE_CORS="true"
+export VIDSNATCH_HTTP_STREAM_DOWNLOADS="false"
+```
+
+## HTTP Endpoints
+
+### Root Endpoint
+- **GET** `/` - Server information and status
+
+### MCP Protocol Endpoint
+- **POST** `/mcp` - Main MCP communication endpoint
+- **GET** `/mcp` - Server-sent events stream for notifications
+
+## MCP Protocol Support
+
+### Supported Methods
+
+1. **initialize** - Initialize MCP connection
+2. **tools/list** - List available tools
+3. **tools/call** - Execute tools (with streaming support)
+
+### Available Tools
+
+1. **get_video_info** - Get YouTube video information
+2. **download_video** - Download video (with streaming progress)
+3. **download_audio** - Download audio (with streaming progress)
+4. **download_transcript** - Download transcript (with streaming progress)
+5. **download_video_segment** - Download video segment (with streaming progress)
+6. **list_downloads** - List downloaded files
+7. **get_config** - Get server configuration
+
+## Streaming Downloads
+
+For long-running operations (downloads), the server supports SSE streaming:
+
+```bash
+# This will return an SSE stream with progress updates
+curl -X POST http://localhost:8090/mcp \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": "3",
+    "method": "tools/call",
+    "params": {
+      "name": "download_video",
+      "arguments": {
+        "url": "https://youtube.com/watch?v=VIDEO_ID",
+        "quality": "720p"
+      }
+    }
+  }'
+```
+
+Response format for streaming:
+```
+data: {"jsonrpc": "2.0", "id": "3", "result": {"streaming": true, "status": "started"}}
+
+data: {"jsonrpc": "2.0", "id": "3", "result": {"progress": {"status": "starting", "message": "Starting video download...", "progress": 0}}}
+
+data: {"jsonrpc": "2.0", "id": "3", "result": {"progress": {"status": "processing", "message": "Processing downloaded file...", "progress": 90}}}
+
+data: {"jsonrpc": "2.0", "id": "3", "result": {"content": "{\"status\": \"success\", \"file_path\": \"./downloads/video.mp4\"}", "status": "completed"}}
+```
+
+## Claude Desktop Integration
+
+### HTTP Transport Configuration
+
+Create or update your Claude Desktop configuration:
+
+```json
+{
+  "mcpServers": {
+    "vidsnatch-http": {
+      "command": "python3",
+      "args": ["/path/to/VidSnatch/mcp_http_server.py"],
+      "env": {
+        "VIDSNATCH_DOWNLOAD_DIR": "/Users/username/Downloads/VidSnatch",
+        "VIDSNATCH_HTTP_PORT": "8090"
+      }
+    }
+  }
+}
+```
+
+### Remote Server Configuration
+
+For a remote VidSnatch MCP server:
+
+```json
+{
+  "mcpServers": {
+    "vidsnatch-remote": {
+      "transport": {
+        "type": "http",
+        "url": "http://your-server.com:8090/mcp"
+      }
+    }
+  }
+}
+```
+
+## Deployment
+
+### Local Development
+```bash
+# Start HTTP server
+python3 mcp_http_server.py
+```
+
+### Docker Deployment
+```bash
+# Build and run with HTTP transport
+docker build -t vidsnatch .
+docker run -p 8090:8090 -e MODE=http vidsnatch
+```
+
+### Production Deployment
+
+For production deployment, consider:
+- Using a reverse proxy (nginx)
+- Adding authentication/authorization
+- Implementing rate limiting
+- Using HTTPS with SSL certificates
+
+Example nginx configuration:
+```nginx
+server {
+    listen 443 ssl;
+    server_name your-domain.com;
+    
+    location /mcp {
+        proxy_pass http://localhost:8090;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        
+        # SSE streaming support
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_set_header Connection '';
+        proxy_http_version 1.1;
+        chunked_transfer_encoding off;
+    }
+}
+```
+
+## Comparison: stdio vs HTTP Transport
+
+| Feature | stdio Transport | HTTP Transport |
+|---------|----------------|----------------|
+| **Deployment** | Local only | Local + Remote |
+| **Streaming** | No | Yes (SSE) |
+| **Web Integration** | No | Yes (CORS) |
+| **Multiple Clients** | No | Yes |
+| **Progress Updates** | No | Yes |
+| **Network Overhead** | None | Minimal |
+| **Security** | Process isolation | HTTP/network security |
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Port already in use**
+   ```bash
+   export VIDSNATCH_HTTP_PORT="8091"
+   python3 mcp_http_server.py
+   ```
+
+2. **CORS issues**
+   ```json
+   {"http_transport": {"enable_cors": true}}
+   ```
+
+3. **Connection refused**
+   - Check if server is running: `curl http://localhost:8090/`
+   - Verify port configuration
+   - Check firewall settings
+
+### Debug Mode
+
+Enable debug logging:
+```python
+import logging
+logging.basicConfig(level=logging.DEBUG)
+```
+
+## Examples
+
+See the `examples/` directory for:
+- Claude Desktop configurations
+- Client integration examples
+- Streaming download demos
+- Remote deployment scripts
+
+## API Reference
+
+Complete MCP HTTP API documentation is available in the OpenAPI format at `/docs` when running the server (if enabled in development mode).

--- a/README.md
+++ b/README.md
@@ -247,13 +247,33 @@ The MCP server exposes the following tools:
 
 ### Starting the MCP Server
 
+VidSnatch supports both **stdio** and **HTTP** transports for maximum flexibility:
+
+#### stdio Transport (Local)
 ```bash
-# Start MCP server
+# Start stdio MCP server (original)
 python3 mcp_server.py
 
 # Or using the installed script
 vidsnatch-mcp
 ```
+
+#### HTTP Transport (Local & Remote)
+```bash
+# Start HTTP MCP server with streaming support
+python3 mcp_http_server.py
+
+# Or using the installed script
+vidsnatch-mcp-http
+```
+
+The HTTP server provides:
+- **Remote accessibility** - Run on one machine, access from another
+- **SSE streaming** - Real-time progress updates for downloads
+- **Web compatibility** - CORS support for browser-based clients
+- **Multiple clients** - Handle concurrent connections
+
+Default HTTP endpoint: `http://localhost:8090/mcp`
 
 ### MCP Configuration
 
@@ -415,10 +435,13 @@ result = download_video_segment(
 VidSnatch supports multiple running modes:
 
 - **Web App Mode**: `python3 web_app.py` - Interactive web interface
-- **MCP Server Mode**: `python3 mcp_server.py` - For AI assistants and programmatic access
+- **MCP Server Mode (stdio)**: `python3 mcp_server.py` - For AI assistants (local)
+- **MCP Server Mode (HTTP)**: `python3 mcp_http_server.py` - For remote AI assistants and web clients
 - **CLI Mode**: `python -m youtube_downloader` - Command-line interface
 
 All modes can run independently without interference.
+
+**📖 For detailed HTTP transport documentation, see [MCP_HTTP_README.md](MCP_HTTP_README.md)**
 
 ## Requirements
 

--- a/error.txt
+++ b/error.txt
@@ -1,0 +1,20 @@
+{
+    "mcpServers": {
+        "vidsnatch": {
+            "command": "/opt/homebrew/bin/uv",
+            "args": [
+                "run",
+                "--directory",
+                "/Users/amitrawat/Desktop/Amit/dev/lseg-dev/VidSnatch",
+                "python3",
+                "mcp_server.py"
+            ],
+            "cwd": "/Users/amitrawat/Desktop/Amit/dev/lseg-dev/VidSnatch",
+            "env": {
+                "VIDSNATCH_DOWNLOAD_DIR": "/Users/amitrawat/Downloads/VidSnatch",
+                "VIDSNATCH_VIDEO_QUALITY": "1080p",
+                "VIDSNATCH_AUDIO_QUALITY": "highest"
+            }
+        }
+    }
+}

--- a/examples/claude_desktop_config_docker.json
+++ b/examples/claude_desktop_config_docker.json
@@ -1,0 +1,15 @@
+{
+    "mcpServers": {
+      "vidsnatch": {
+        "command": "docker",
+        "args": [
+          "run", "--rm",
+          "-v", "/Users/amitrawat/Downloads/VidSnatch:/app/downloads",
+          "-e", "VIDSNATCH_DOWNLOAD_DIR=/app/downloads",
+          "-e", "VIDSNATCH_VIDEO_QUALITY=1080p",
+          "-e", "VIDSNATCH_AUDIO_QUALITY=highest",
+          "vidsnatch:latest", "mcp"
+        ]
+      }
+    }
+}

--- a/examples/claude_desktop_config_http.json
+++ b/examples/claude_desktop_config_http.json
@@ -1,0 +1,15 @@
+{
+  "mcpServers": {
+    "vidsnatch-http": {
+      "command": "python3",
+      "args": ["/Users/amitrawat/Desktop/Amit/dev/ls-dev/VidSnatch/mcp_http_server.py"],
+      "env": {
+        "VIDSNATCH_DOWNLOAD_DIR": "/Users/amitrawat/Downloads/VidSnatch",
+        "VIDSNATCH_HTTP_HOST": "127.0.0.1",
+        "VIDSNATCH_HTTP_PORT": "8090",
+        "VIDSNATCH_HTTP_ENABLE_CORS": "true",
+        "VIDSNATCH_HTTP_STREAM_DOWNLOADS": "true"
+      }
+    }
+  }
+}

--- a/examples/claude_desktop_config_python.json
+++ b/examples/claude_desktop_config_python.json
@@ -1,0 +1,20 @@
+{
+    "mcpServers": {
+        "vidsnatch": {
+            "command": "/opt/homebrew/bin/uv",
+            "args": [
+                "run",
+                "--directory",
+                "/Users/amitrawat/Desktop/Amit/dev/lseg-dev/VidSnatch",
+                "python3",
+                "mcp_server.py"
+            ],
+            "cwd": "/Users/amitrawat/Desktop/Amit/dev/lseg-dev/VidSnatch",
+            "env": {
+                "VIDSNATCH_DOWNLOAD_DIR": "/Users/amitrawat/Downloads/VidSnatch",
+                "VIDSNATCH_VIDEO_QUALITY": "720p",
+                "VIDSNATCH_AUDIO_QUALITY": "128kbps"
+            }
+        }
+    }
+}

--- a/examples/claude_desktop_config_remote.json
+++ b/examples/claude_desktop_config_remote.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "vidsnatch-remote": {
+      "transport": {
+        "type": "http",
+        "url": "http://your-server.com:8090/mcp"
+      }
+    }
+  }
+}

--- a/mcp_config.json
+++ b/mcp_config.json
@@ -4,5 +4,12 @@
   "default_audio_quality": "highest",
   "max_file_size_mb": 500,
   "allowed_formats": ["mp4", "webm", "mp3", "m4a"],
-  "create_subdirs": true
+  "create_subdirs": true,
+  "http_transport": {
+    "enabled": true,
+    "host": "0.0.0.0",
+    "port": 8090,
+    "enable_cors": true,
+    "stream_downloads": true
+  }
 }

--- a/mcp_config.py
+++ b/mcp_config.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""
+VidSnatch MCP Configuration - Shared configuration for both stdio and HTTP transports
+"""
+
+import json
+import os
+from typing import Dict, Any
+
+
+def load_config() -> Dict[str, Any]:
+    """Load MCP server configuration with environment variable overrides"""
+    config_path = "mcp_config.json"
+    if os.path.exists(config_path):
+        with open(config_path, 'r') as f:
+            config = json.load(f)
+    else:
+        # Default configuration
+        config = {
+            "download_directory": "./downloads",
+            "default_video_quality": "highest",
+            "default_audio_quality": "highest",
+            "max_file_size_mb": 500,
+            "allowed_formats": ["mp4", "webm", "mp3", "m4a"],
+            "create_subdirs": True,
+            "http_transport": {
+                "enabled": False,
+                "host": "0.0.0.0",
+                "port": 8090,
+                "enable_cors": True,
+                "stream_downloads": True
+            }
+        }
+    
+    # Override with environment variables if provided
+    if os.getenv("VIDSNATCH_DOWNLOAD_DIR"):
+        config["download_directory"] = os.getenv("VIDSNATCH_DOWNLOAD_DIR")
+    
+    if os.getenv("VIDSNATCH_VIDEO_QUALITY"):
+        config["default_video_quality"] = os.getenv("VIDSNATCH_VIDEO_QUALITY")
+        
+    if os.getenv("VIDSNATCH_AUDIO_QUALITY"):
+        config["default_audio_quality"] = os.getenv("VIDSNATCH_AUDIO_QUALITY")
+        
+    if os.getenv("VIDSNATCH_MAX_FILE_SIZE_MB"):
+        config["max_file_size_mb"] = int(os.getenv("VIDSNATCH_MAX_FILE_SIZE_MB"))
+    
+    # HTTP transport environment overrides
+    if os.getenv("VIDSNATCH_HTTP_HOST"):
+        config["http_transport"]["host"] = os.getenv("VIDSNATCH_HTTP_HOST")
+        
+    if os.getenv("VIDSNATCH_HTTP_PORT"):
+        config["http_transport"]["port"] = int(os.getenv("VIDSNATCH_HTTP_PORT"))
+        
+    if os.getenv("VIDSNATCH_HTTP_ENABLE_CORS"):
+        config["http_transport"]["enable_cors"] = os.getenv("VIDSNATCH_HTTP_ENABLE_CORS").lower() == "true"
+        
+    if os.getenv("VIDSNATCH_HTTP_STREAM_DOWNLOADS"):
+        config["http_transport"]["stream_downloads"] = os.getenv("VIDSNATCH_HTTP_STREAM_DOWNLOADS").lower() == "true"
+    
+    return config
+
+
+def ensure_download_directory(config: Dict[str, Any]) -> None:
+    """Ensure the download directory exists"""
+    os.makedirs(config["download_directory"], exist_ok=True)

--- a/mcp_http_server.py
+++ b/mcp_http_server.py
@@ -1,0 +1,429 @@
+#!/usr/bin/env python3
+"""
+VidSnatch MCP HTTP Server - Model Context Protocol server with HTTP transport and SSE streaming
+"""
+
+import json
+import asyncio
+import logging
+from typing import Dict, Any, Optional, AsyncGenerator
+from fastapi import FastAPI, Request, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import StreamingResponse, JSONResponse
+from pydantic import BaseModel
+from mcp_config import load_config, ensure_download_directory
+from mcp_tools import MCPTools
+
+
+class MCPRequest(BaseModel):
+    """MCP request model"""
+    jsonrpc: str = "2.0"
+    id: Optional[str] = None
+    method: str
+    params: Optional[Dict[str, Any]] = None
+
+
+class MCPResponse(BaseModel):
+    """MCP response model"""
+    jsonrpc: str = "2.0"
+    id: Optional[str] = None
+    result: Optional[Dict[str, Any]] = None
+    error: Optional[Dict[str, Any]] = None
+
+
+class MCPHTTPServer:
+    """HTTP-based MCP server with SSE streaming support"""
+    
+    def __init__(self):
+        self.config = load_config()
+        self.logger = logging.getLogger("vidsnatch-mcp-http")
+        
+        # Setup logging for HTTP mode (can use normal logging)
+        if not self.logger.handlers:
+            handler = logging.StreamHandler()
+            handler.setFormatter(logging.Formatter(
+                '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+            ))
+            self.logger.addHandler(handler)
+            self.logger.setLevel(logging.INFO)
+        
+        ensure_download_directory(self.config)
+        self.tools = MCPTools(self.config, self.logger)
+        
+        # Initialize FastAPI app
+        self.app = FastAPI(
+            title="VidSnatch MCP HTTP Server",
+            description="HTTP transport for VidSnatch MCP server with SSE streaming",
+            version="1.0.0"
+        )
+        
+        # Add CORS middleware if enabled
+        if self.config.get("http_transport", {}).get("enable_cors", True):
+            self.app.add_middleware(
+                CORSMiddleware,
+                allow_origins=["*"],
+                allow_credentials=False,
+                allow_methods=["GET", "POST", "OPTIONS"],
+                allow_headers=["*"],
+            )
+        
+        self.setup_routes()
+    
+    def setup_routes(self):
+        """Setup HTTP routes for MCP protocol"""
+        
+        @self.app.get("/")
+        async def root():
+            """Root endpoint with server info"""
+            return {
+                "name": "VidSnatch MCP HTTP Server",
+                "version": "1.0.0",
+                "description": "HTTP transport for VidSnatch MCP server",
+                "mcp_endpoint": "/mcp",
+                "transport": "http",
+                "streaming_supported": True
+            }
+        
+        @self.app.post("/mcp")
+        async def mcp_endpoint(request: MCPRequest):
+            """Main MCP communication endpoint"""
+            try:
+                self.logger.info(f"MCP Request: {request.method}")
+                
+                # Handle different MCP methods
+                if request.method == "initialize":
+                    return await self.handle_initialize(request)
+                elif request.method == "tools/list":
+                    return await self.handle_tools_list(request)
+                elif request.method == "tools/call":
+                    return await self.handle_tools_call(request)
+                else:
+                    return MCPResponse(
+                        id=request.id,
+                        error={
+                            "code": -32601,
+                            "message": f"Method not found: {request.method}"
+                        }
+                    ).dict()
+                    
+            except Exception as e:
+                self.logger.error(f"MCP endpoint error: {str(e)}")
+                return MCPResponse(
+                    id=request.id,
+                    error={
+                        "code": -32603,
+                        "message": f"Internal error: {str(e)}"
+                    }
+                ).dict()
+        
+        @self.app.get("/mcp")
+        async def mcp_notifications():
+            """SSE endpoint for server notifications (optional)"""
+            return StreamingResponse(
+                self.notification_stream(),
+                media_type="text/event-stream",
+                headers={
+                    "Cache-Control": "no-cache",
+                    "Connection": "keep-alive",
+                }
+            )
+    
+    async def handle_initialize(self, request: MCPRequest) -> Dict[str, Any]:
+        """Handle MCP initialize request"""
+        return MCPResponse(
+            id=request.id,
+            result={
+                "protocolVersion": "2024-11-05",
+                "capabilities": {
+                    "tools": {},
+                    "notifications": {},
+                    "streaming": True
+                },
+                "serverInfo": {
+                    "name": "vidsnatch-http",
+                    "version": "1.0.0"
+                }
+            }
+        ).dict()
+    
+    async def handle_tools_list(self, request: MCPRequest) -> Dict[str, Any]:
+        """Handle tools/list request"""
+        tools_list = [
+            {
+                "name": "get_video_info",
+                "description": "Get detailed information about a YouTube video",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "url": {"type": "string", "description": "YouTube video URL or video ID"}
+                    },
+                    "required": ["url"]
+                }
+            },
+            {
+                "name": "download_video",
+                "description": "Download a YouTube video",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "url": {"type": "string", "description": "YouTube video URL or video ID"},
+                        "quality": {"type": "string", "description": "Video quality", "default": "highest"},
+                        "resolution": {"type": "string", "description": "Specific resolution (optional)"}
+                    },
+                    "required": ["url"]
+                }
+            },
+            {
+                "name": "download_audio",
+                "description": "Download audio from a YouTube video",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "url": {"type": "string", "description": "YouTube video URL or video ID"},
+                        "quality": {"type": "string", "description": "Audio quality", "default": "highest"},
+                        "format": {"type": "string", "description": "Audio format", "default": "mp3"}
+                    },
+                    "required": ["url"]
+                }
+            },
+            {
+                "name": "download_transcript",
+                "description": "Download transcript from a YouTube video",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "url": {"type": "string", "description": "YouTube video URL or video ID"},
+                        "language": {"type": "string", "description": "Language code", "default": "en"}
+                    },
+                    "required": ["url"]
+                }
+            },
+            {
+                "name": "download_video_segment",
+                "description": "Download a specific segment from a YouTube video",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "url": {"type": "string", "description": "YouTube video URL or video ID"},
+                        "start_time": {"type": "number", "description": "Start time in seconds"},
+                        "end_time": {"type": "number", "description": "End time in seconds"},
+                        "quality": {"type": "string", "description": "Video quality", "default": "highest"}
+                    },
+                    "required": ["url", "start_time", "end_time"]
+                }
+            },
+            {
+                "name": "list_downloads",
+                "description": "List all files in the download directory",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {}
+                }
+            },
+            {
+                "name": "get_config",
+                "description": "Get current server configuration",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {}
+                }
+            }
+        ]
+        
+        return MCPResponse(
+            id=request.id,
+            result={"tools": tools_list}
+        ).dict()
+    
+    async def handle_tools_call(self, request: MCPRequest) -> Dict[str, Any]:
+        """Handle tools/call request with optional streaming"""
+        if not request.params:
+            return MCPResponse(
+                id=request.id,
+                error={"code": -32602, "message": "Missing params"}
+            ).dict()
+        
+        tool_name = request.params.get("name")
+        arguments = request.params.get("arguments", {})
+        
+        if not tool_name:
+            return MCPResponse(
+                id=request.id,
+                error={"code": -32602, "message": "Missing tool name"}
+            ).dict()
+        
+        # Check if streaming is requested and supported for this tool
+        streaming_tools = ["download_video", "download_audio", "download_transcript", "download_video_segment"]
+        should_stream = (
+            self.config.get("http_transport", {}).get("stream_downloads", True) and
+            tool_name in streaming_tools
+        )
+        
+        if should_stream:
+            # Return streaming response
+            return StreamingResponse(
+                self.stream_tool_execution(request.id, tool_name, arguments),
+                media_type="text/event-stream",
+                headers={
+                    "Cache-Control": "no-cache",
+                    "Connection": "keep-alive",
+                }
+            )
+        else:
+            # Return regular JSON response
+            try:
+                result = await self.execute_tool(tool_name, arguments)
+                return MCPResponse(id=request.id, result={"content": result}).dict()
+            except Exception as e:
+                return MCPResponse(
+                    id=request.id,
+                    error={"code": -32603, "message": str(e)}
+                ).dict()
+    
+    async def execute_tool(self, tool_name: str, arguments: Dict[str, Any]) -> str:
+        """Execute a tool and return the result"""
+        if tool_name == "get_video_info":
+            return self.tools.get_video_info(arguments.get("url"))
+        elif tool_name == "download_video":
+            return self.tools.download_video(
+                arguments.get("url"),
+                arguments.get("quality", "highest"),
+                arguments.get("resolution")
+            )
+        elif tool_name == "download_audio":
+            return self.tools.download_audio(
+                arguments.get("url"),
+                arguments.get("quality", "highest"),
+                arguments.get("format", "mp3")
+            )
+        elif tool_name == "download_transcript":
+            return self.tools.download_transcript(
+                arguments.get("url"),
+                arguments.get("language", "en")
+            )
+        elif tool_name == "download_video_segment":
+            return self.tools.download_video_segment(
+                arguments.get("url"),
+                arguments.get("start_time"),
+                arguments.get("end_time"),
+                arguments.get("quality", "highest")
+            )
+        elif tool_name == "list_downloads":
+            return self.tools.list_downloads()
+        elif tool_name == "get_config":
+            return self.tools.get_config()
+        else:
+            raise ValueError(f"Unknown tool: {tool_name}")
+    
+    async def stream_tool_execution(
+        self, 
+        request_id: Optional[str], 
+        tool_name: str, 
+        arguments: Dict[str, Any]
+    ) -> AsyncGenerator[str, None]:
+        """Stream tool execution with progress updates"""
+        
+        progress_updates = []
+        
+        def progress_callback(update: Dict[str, Any]):
+            progress_updates.append(update)
+        
+        try:
+            # Send initial response
+            initial_response = MCPResponse(
+                id=request_id,
+                result={"streaming": True, "status": "started"}
+            )
+            yield f"data: {json.dumps(initial_response.dict())}\n\n"
+            
+            # Execute tool with progress callback in a separate task
+            if tool_name == "download_video":
+                result = self.tools.download_video(
+                    arguments.get("url"),
+                    arguments.get("quality", "highest"),
+                    arguments.get("resolution"),
+                    progress_callback
+                )
+            elif tool_name == "download_audio":
+                result = self.tools.download_audio(
+                    arguments.get("url"),
+                    arguments.get("quality", "highest"),
+                    arguments.get("format", "mp3"),
+                    progress_callback
+                )
+            elif tool_name == "download_transcript":
+                result = self.tools.download_transcript(
+                    arguments.get("url"),
+                    arguments.get("language", "en"),
+                    progress_callback
+                )
+            elif tool_name == "download_video_segment":
+                result = self.tools.download_video_segment(
+                    arguments.get("url"),
+                    arguments.get("start_time"),
+                    arguments.get("end_time"),
+                    arguments.get("quality", "highest"),
+                    progress_callback
+                )
+            else:
+                raise ValueError(f"Streaming not supported for tool: {tool_name}")
+            
+            # Stream any progress updates that were collected
+            for update in progress_updates:
+                progress_response = MCPResponse(
+                    id=request_id,
+                    result={"progress": update}
+                )
+                yield f"data: {json.dumps(progress_response.dict())}\n\n"
+                await asyncio.sleep(0.1)  # Small delay for better streaming experience
+            
+            # Send final result
+            final_response = MCPResponse(
+                id=request_id,
+                result={"content": result, "status": "completed"}
+            )
+            yield f"data: {json.dumps(final_response.dict())}\n\n"
+            
+        except Exception as e:
+            error_response = MCPResponse(
+                id=request_id,
+                error={"code": -32603, "message": str(e)}
+            )
+            yield f"data: {json.dumps(error_response.dict())}\n\n"
+    
+    async def notification_stream(self) -> AsyncGenerator[str, None]:
+        """Generate server-sent events for notifications"""
+        # This is a placeholder for server notifications
+        # In a real implementation, you might want to send periodic status updates
+        while True:
+            await asyncio.sleep(30)  # Send a heartbeat every 30 seconds
+            heartbeat = {"type": "heartbeat", "timestamp": asyncio.get_event_loop().time()}
+            yield f"data: {json.dumps(heartbeat)}\n\n"
+
+
+def main():
+    """Main entry point for HTTP MCP server"""
+    import uvicorn
+    
+    server = MCPHTTPServer()
+    
+    # Get HTTP configuration
+    http_config = server.config.get("http_transport", {})
+    host = http_config.get("host", "0.0.0.0")
+    port = http_config.get("port", 8090)
+    
+    server.logger.info(f"🚀 Starting VidSnatch MCP HTTP server...")
+    server.logger.info(f"📡 MCP endpoint: http://{host}:{port}/mcp")
+    server.logger.info(f"📊 Server info: http://{host}:{port}/")
+    server.logger.info(f"🔄 Streaming: {'enabled' if http_config.get('stream_downloads', True) else 'disabled'}")
+    
+    uvicorn.run(
+        server.app,
+        host=host,
+        port=port,
+        log_level="info"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/mcp_tools.py
+++ b/mcp_tools.py
@@ -1,0 +1,440 @@
+#!/usr/bin/env python3
+"""
+VidSnatch MCP Tools - Shared tools for both stdio and HTTP transports
+"""
+
+import json
+import os
+import logging
+from typing import Optional, Dict, Any, Callable
+from src import YouTubeDownloader
+
+
+class MCPTools:
+    """Shared MCP tools implementation that can be used by both stdio and HTTP transports"""
+    
+    def __init__(self, config: Dict[str, Any], logger: Optional[logging.Logger] = None):
+        self.config = config
+        self.logger = logger or logging.getLogger("vidsnatch-mcp-tools")
+        self.downloader = YouTubeDownloader()
+        
+    def get_video_info(self, url: str) -> str:
+        """
+        Get detailed information about a YouTube video including title, duration, and available formats.
+        
+        Use this tool to understand video content before processing. For long videos where users want
+        specific segments, consider following up with download_transcript to get timestamped content
+        that can help locate specific topics or discussions.
+        
+        Args:
+            url: YouTube video URL or video ID
+            
+        Returns:
+            JSON string containing video information including title, duration, formats, etc.
+        """
+        try:
+            self.logger.info(f"Getting video info for: {url}")
+            video_info = self.downloader.get_video_info(url)
+            return json.dumps(video_info, indent=2)
+        except Exception as e:
+            error_msg = f"Failed to get video information: {str(e)}"
+            self.logger.error(error_msg)
+            return json.dumps({"error": error_msg})
+
+    def download_video(
+        self, 
+        url: str, 
+        quality: str = "highest",
+        resolution: Optional[str] = None,
+        progress_callback: Optional[Callable[[dict], None]] = None
+    ) -> str:
+        """
+        Download a YouTube video to the configured download directory.
+        
+        Args:
+            url: YouTube video URL or video ID
+            quality: Video quality preference ("highest", "lowest", or specific quality like "720p")
+            resolution: Specific resolution (e.g., "1080p", "720p", "480p") - overrides quality if provided
+            progress_callback: Optional callback for progress updates (HTTP streaming)
+            
+        Returns:
+            JSON string with download status and file path
+        """
+        try:
+            self.logger.info(f"Downloading video: {url} with quality: {quality}")
+            
+            if progress_callback:
+                progress_callback({
+                    "status": "starting", 
+                    "message": f"Starting video download for: {url}",
+                    "progress": 0
+                })
+            
+            # Use resolution if provided, otherwise use quality
+            download_quality = resolution if resolution else quality
+            
+            # Download to configured directory
+            downloaded_file = self.downloader.download_video(
+                url, 
+                self.config["download_directory"], 
+                download_quality
+            )
+            
+            if progress_callback:
+                progress_callback({
+                    "status": "processing", 
+                    "message": "Processing downloaded file...",
+                    "progress": 90
+                })
+            
+            file_size_mb = os.path.getsize(downloaded_file) / (1024 * 1024)
+            
+            result = {
+                "status": "success",
+                "file_path": downloaded_file,
+                "file_size_mb": round(file_size_mb, 2),
+                "download_directory": self.config["download_directory"]
+            }
+            
+            if progress_callback:
+                progress_callback({
+                    "status": "completed", 
+                    "message": f"Video downloaded successfully: {os.path.basename(downloaded_file)}",
+                    "progress": 100,
+                    "result": result
+                })
+            
+            self.logger.info(f"Video downloaded successfully: {downloaded_file}")
+            return json.dumps(result, indent=2)
+            
+        except Exception as e:
+            error_msg = f"Failed to download video: {str(e)}"
+            self.logger.error(error_msg)
+            error_result = {"status": "error", "error": error_msg}
+            
+            if progress_callback:
+                progress_callback({
+                    "status": "error", 
+                    "message": error_msg,
+                    "result": error_result
+                })
+            
+            return json.dumps(error_result)
+
+    def download_audio(
+        self, 
+        url: str, 
+        quality: str = "highest",
+        format: str = "mp3",
+        progress_callback: Optional[Callable[[dict], None]] = None
+    ) -> str:
+        """
+        Download audio from a YouTube video to the configured download directory.
+        
+        Args:
+            url: YouTube video URL or video ID
+            quality: Audio quality preference ("highest", "lowest", or specific bitrate like "128kbps")
+            format: Audio format preference ("mp3", "m4a", "wav")
+            progress_callback: Optional callback for progress updates (HTTP streaming)
+            
+        Returns:
+            JSON string with download status and file path
+        """
+        try:
+            self.logger.info(f"Downloading audio: {url} with quality: {quality}, format: {format}")
+            
+            if progress_callback:
+                progress_callback({
+                    "status": "starting", 
+                    "message": f"Starting audio download for: {url}",
+                    "progress": 0
+                })
+            
+            # Download to configured directory
+            downloaded_file = self.downloader.download_audio(
+                url, 
+                self.config["download_directory"], 
+                quality
+            )
+            
+            if progress_callback:
+                progress_callback({
+                    "status": "processing", 
+                    "message": "Processing downloaded audio...",
+                    "progress": 90
+                })
+            
+            file_size_mb = os.path.getsize(downloaded_file) / (1024 * 1024)
+            
+            result = {
+                "status": "success",
+                "file_path": downloaded_file,
+                "file_size_mb": round(file_size_mb, 2),
+                "download_directory": self.config["download_directory"],
+                "format": format
+            }
+            
+            if progress_callback:
+                progress_callback({
+                    "status": "completed", 
+                    "message": f"Audio downloaded successfully: {os.path.basename(downloaded_file)}",
+                    "progress": 100,
+                    "result": result
+                })
+            
+            self.logger.info(f"Audio downloaded successfully: {downloaded_file}")
+            return json.dumps(result, indent=2)
+            
+        except Exception as e:
+            error_msg = f"Failed to download audio: {str(e)}"
+            self.logger.error(error_msg)
+            error_result = {"status": "error", "error": error_msg}
+            
+            if progress_callback:
+                progress_callback({
+                    "status": "error", 
+                    "message": error_msg,
+                    "result": error_result
+                })
+            
+            return json.dumps(error_result)
+
+    def download_transcript(
+        self, 
+        url: str, 
+        language: str = "en",
+        progress_callback: Optional[Callable[[dict], None]] = None
+    ) -> str:
+        """
+        Download transcript with timestamps from a YouTube video. This is ESSENTIAL for finding specific topics or segments in videos.
+        
+        The transcript includes precise timestamps for each spoken segment, making it perfect for:
+        - Locating when specific topics are discussed (e.g., "Windsurf deal", "AI features", etc.)
+        - Finding exact time ranges for creating video clips
+        - Searching through long videos to identify relevant sections
+        
+        WORKFLOW TIP: Always download the transcript FIRST when users ask for clips about specific topics,
+        then use the timestamps to determine start_time and end_time for download_video_segment.
+        
+        Args:
+            url: YouTube video URL or video ID
+            language: Language code for transcript (e.g., "en", "es", "fr")
+            progress_callback: Optional callback for progress updates (HTTP streaming)
+            
+        Returns:
+            JSON string with download status, file path, and full transcript content with timestamps.
+            The transcript_content field contains the complete transcript text that can be analyzed directly.
+        """
+        try:
+            self.logger.info(f"Downloading transcript: {url} with language: {language}")
+            
+            if progress_callback:
+                progress_callback({
+                    "status": "starting", 
+                    "message": f"Starting transcript download for: {url}",
+                    "progress": 0
+                })
+            
+            # Download to configured directory
+            downloaded_file = self.downloader.download_transcript(
+                url, 
+                self.config["download_directory"], 
+                language
+            )
+            
+            if progress_callback:
+                progress_callback({
+                    "status": "processing", 
+                    "message": "Processing transcript...",
+                    "progress": 80
+                })
+            
+            file_size_mb = os.path.getsize(downloaded_file) / (1024 * 1024)
+            
+            # Read transcript content to include in response
+            try:
+                with open(downloaded_file, 'r', encoding='utf-8') as f:
+                    transcript_content = f.read()
+            except Exception as read_error:
+                self.logger.warning(f"Could not read transcript file: {read_error}")
+                transcript_content = None
+            
+            result = {
+                "status": "success",
+                "file_path": downloaded_file,
+                "file_size_mb": round(file_size_mb, 2),
+                "download_directory": self.config["download_directory"],
+                "language": language,
+                "transcript_content": transcript_content
+            }
+            
+            if progress_callback:
+                progress_callback({
+                    "status": "completed", 
+                    "message": f"Transcript downloaded successfully: {os.path.basename(downloaded_file)}",
+                    "progress": 100,
+                    "result": result
+                })
+            
+            self.logger.info(f"Transcript downloaded successfully: {downloaded_file}")
+            return json.dumps(result, indent=2)
+            
+        except Exception as e:
+            error_msg = f"Failed to download transcript: {str(e)}"
+            self.logger.error(error_msg)
+            error_result = {"status": "error", "error": error_msg}
+            
+            if progress_callback:
+                progress_callback({
+                    "status": "error", 
+                    "message": error_msg,
+                    "result": error_result
+                })
+            
+            return json.dumps(error_result)
+
+    def download_video_segment(
+        self,
+        url: str,
+        start_time: float,
+        end_time: float,
+        quality: str = "highest",
+        progress_callback: Optional[Callable[[dict], None]] = None
+    ) -> str:
+        """
+        Download a specific segment/clip from a YouTube video using precise timestamps.
+        
+        IMPORTANT: When users request clips about specific topics (e.g., "download the part about X"),
+        you should FIRST use download_transcript to get the timestamped transcript, then analyze it to
+        find the exact time range when that topic is discussed, and finally use those timestamps here.
+        
+        This tool is perfect for:
+        - Creating short clips from long videos
+        - Extracting specific discussions or segments
+        - Sharing relevant portions without downloading entire videos
+        
+        Args:
+            url: YouTube video URL or video ID
+            start_time: Start time in seconds (get from transcript analysis)
+            end_time: End time in seconds (get from transcript analysis)
+            quality: Video quality preference ("highest", "720p", "480p", etc.)
+            progress_callback: Optional callback for progress updates (HTTP streaming)
+            
+        Returns:
+            JSON string with download status and file path to the video segment
+        """
+        try:
+            self.logger.info(f"Downloading video segment: {url} from {start_time}s to {end_time}s")
+            
+            if start_time >= end_time:
+                raise ValueError("Start time must be less than end time")
+            
+            if progress_callback:
+                progress_callback({
+                    "status": "starting", 
+                    "message": f"Starting video segment download: {start_time}s to {end_time}s",
+                    "progress": 0
+                })
+            
+            # Download to configured directory
+            downloaded_file = self.downloader.download_video_segment(
+                url, 
+                start_time,
+                end_time,
+                self.config["download_directory"], 
+                quality
+            )
+            
+            if progress_callback:
+                progress_callback({
+                    "status": "processing", 
+                    "message": "Processing video segment...",
+                    "progress": 90
+                })
+            
+            file_size_mb = os.path.getsize(downloaded_file) / (1024 * 1024)
+            
+            result = {
+                "status": "success",
+                "file_path": downloaded_file,
+                "file_size_mb": round(file_size_mb, 2),
+                "download_directory": self.config["download_directory"],
+                "start_time": start_time,
+                "end_time": end_time,
+                "duration": end_time - start_time
+            }
+            
+            if progress_callback:
+                progress_callback({
+                    "status": "completed", 
+                    "message": f"Video segment downloaded successfully: {os.path.basename(downloaded_file)}",
+                    "progress": 100,
+                    "result": result
+                })
+            
+            self.logger.info(f"Video segment downloaded successfully: {downloaded_file}")
+            return json.dumps(result, indent=2)
+            
+        except Exception as e:
+            error_msg = f"Failed to download video segment: {str(e)}"
+            self.logger.error(error_msg)
+            error_result = {"status": "error", "error": error_msg}
+            
+            if progress_callback:
+                progress_callback({
+                    "status": "error", 
+                    "message": error_msg,
+                    "result": error_result
+                })
+            
+            return json.dumps(error_result)
+
+    def list_downloads(self) -> str:
+        """
+        List all files in the download directory.
+        
+        Returns:
+            JSON string with list of downloaded files and their information
+        """
+        try:
+            download_dir = self.config["download_directory"]
+            
+            if not os.path.exists(download_dir):
+                return json.dumps({"files": [], "total_count": 0, "directory": download_dir})
+            
+            files = []
+            for filename in os.listdir(download_dir):
+                file_path = os.path.join(download_dir, filename)
+                if os.path.isfile(file_path):
+                    file_size_mb = os.path.getsize(file_path) / (1024 * 1024)
+                    files.append({
+                        "filename": filename,
+                        "file_path": file_path,
+                        "size_mb": round(file_size_mb, 2),
+                        "modified_time": os.path.getmtime(file_path)
+                    })
+            
+            # Sort by modification time (newest first)
+            files.sort(key=lambda x: x["modified_time"], reverse=True)
+            
+            result = {
+                "files": files,
+                "total_count": len(files),
+                "directory": download_dir
+            }
+            
+            return json.dumps(result, indent=2)
+            
+        except Exception as e:
+            error_msg = f"Failed to list downloads: {str(e)}"
+            self.logger.error(error_msg)
+            return json.dumps({"error": error_msg})
+
+    def get_config(self) -> str:
+        """
+        Get the current MCP server configuration.
+        
+        Returns:
+            JSON string with current configuration settings
+        """
+        return json.dumps(self.config, indent=2)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
 vidsnatch = "src.main:main"
 vidsnatch-web = "web_app:main"
 vidsnatch-mcp = "mcp_server:main"
+vidsnatch-mcp-http = "mcp_http_server:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src"]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds HTTP MCP transport with SSE streaming, shared tools/config, stdio server refactor, config/entry updates, SSL workaround in downloader, and comprehensive docs/examples.
> 
> - **MCP HTTP Transport (FastAPI)**:
>   - Adds HTTP server `mcp_http_server.py` with single `/mcp` endpoint, SSE support for long-running `tools/call`, CORS, and heartbeat notifications.
>   - Implements request/response models and handlers for `initialize`, `tools/list`, and all tools; streams final results.
> - **Shared Core**:
>   - Introduces `mcp_tools.py` consolidating tool logic (video/audio/transcript/segment, listings, config) for reuse by stdio/HTTP.
>   - Adds `mcp_config.py` with JSON config + env overrides, and `ensure_download_directory`.
> - **Stdio Server Refactor**:
>   - Simplifies `mcp_server.py` to use `MCPTools` and shared config; disables logging for clean stdio.
> - **Configuration**:
>   - Extends `mcp_config.json` with `http_transport` (host/port/CORS/streaming).
>   - Adds script entry `vidsnatch-mcp-http` in `pyproject.toml`.
> - **Downloader Robustness**:
>   - In `src/downloader.py`, adds SSL workaround: unverified HTTPS context, suppress warnings, and patch `requests` to disable SSL verification for transcript API.
> - **Docs & Examples**:
>   - New `MCP_HTTP_README.md` with setup, endpoints, streaming examples, deployment.
>   - Updates `README.md` to document HTTP transport and modes; links detailed doc.
>   - Adds example Claude configs: `examples/claude_desktop_config_*.json` (python, docker, http, remote).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 03a6113308592a9445015ee4ff4432f82a3ea51a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->